### PR TITLE
Make it possible to continue mapping of building corner points

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,15 +64,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Choco install qgis
+      - name: Choco install qgis-ltr 3.22.5
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install qgis-ltr -y
+          args: install qgis-ltr -y --version 3.22.5
 
       - name: Run tests
         shell: pwsh
         run: |
-          $env:PATH="C:\Program Files\QGIS 3.16\bin;$env:PATH"
+          $env:PATH="C:\Program Files\QGIS 3.22.5\bin;$env:PATH"
           $env:QGIS_PLUGIN_IN_CI=1
           python-qgis-ltr.bat -m pip install -q pytest
           python-qgis-ltr.bat -m pytest -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/kimu/core/rectangular_tool.py
+++ b/kimu/core/rectangular_tool.py
@@ -119,7 +119,7 @@ class RectangularMapping(SelectTool):
         points_b = self._locate_point_b(line_coords, point_a)
 
         corners: List[List[Decimal]]
-        corners = [[]]
+        corners = []
 
         corners = self._add_scratch_layers(points_b, corners)
 

--- a/kimu/core/rectangular_tool.py
+++ b/kimu/core/rectangular_tool.py
@@ -17,7 +17,7 @@ from qgis.core import (
     QgsVectorLayerSimpleLabeling,
     QgsWkbTypes,
 )
-from qgis.gui import QgisInterface, QgsMapToolEmitPoint
+from qgis.gui import QgsMapToolEmitPoint
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QColor, QFont
 from qgis.utils import iface
@@ -33,9 +33,7 @@ LOGGER = setup_logger(plugin_name())
 
 
 class RectangularMapping(SelectTool):
-    def __init__(
-        self, iface: QgisInterface, dock_widget: RectangularDockWidget
-    ) -> None:
+    def __init__(self, dock_widget: RectangularDockWidget) -> None:
         super().__init__(iface)
         self.ui: RectangularDockWidget = dock_widget
 

--- a/kimu/core/rectangular_tool.py
+++ b/kimu/core/rectangular_tool.py
@@ -47,34 +47,29 @@ class RectangularMapping(SelectTool):
             self.layer = layer
             self.setLayer(self.layer)
 
-    # fmt: off
-    def canvasPressEvent(  # noqa: N802
-        self, event: QgsMapToolEmitPoint
-    ) -> None:
-        # fmt: on
+    def canvasPressEvent(self, event: QgsMapToolEmitPoint) -> None:  # noqa: N802
         """Canvas click event."""
         if self.iface.activeLayer() != self.layer:
-            LOGGER.warning(tr("Please select a line layer"),
-                           extra={"details": ""})
+            LOGGER.warning(tr("Please select a line layer"), extra={"details": ""})
             return
 
         if QgsWkbTypes.isSingleType(
-            list(
-                self.iface.activeLayer().getFeatures()
-            )[0].geometry().wkbType()
+            list(self.iface.activeLayer().getFeatures())[0].geometry().wkbType()
         ):
             pass
         else:
             LOGGER.warning(
-                tr("Please select a line layer with "
-                   "LineString geometries (instead "
-                   "of MultiLineString geometries)"),
-                extra={"details": ""})
+                tr(
+                    "Please select a line layer with "
+                    "LineString geometries (instead "
+                    "of MultiLineString geometries)"
+                ),
+                extra={"details": ""},
+            )
             return
 
         if len(self.iface.activeLayer().selectedFeatures()) != 1:
-            LOGGER.warning(tr("Please select only one line"),
-                           extra={"details": ""})
+            LOGGER.warning(tr("Please select only one line"), extra={"details": ""})
             return
 
         geometry = self.iface.activeLayer().selectedFeatures()[0].geometry()
@@ -94,9 +89,13 @@ class RectangularMapping(SelectTool):
             point1 = QgsPointXY(line_feat[-1])
             point2 = QgsPointXY(line_feat[0])
         else:
-            LOGGER.warning(tr("Please select start or end point of the "
-                              "selected property boundary line."
-                              ), extra={"details": ""})
+            LOGGER.warning(
+                tr(
+                    "Please select start or end point of the "
+                    "selected property boundary line."
+                ),
+                extra={"details": ""},
+            )
             return
 
         line_coords = [
@@ -125,9 +124,7 @@ class RectangularMapping(SelectTool):
         crs = self.layer.crs()
         options_layer.setCrs(crs)
         options_layer_dataprovider = options_layer.dataProvider()
-        options_layer_dataprovider.addAttributes(
-            [QgsField("id", QVariant.String)]
-        )
+        options_layer_dataprovider.addAttributes([QgsField("id", QVariant.String)])
         options_layer.updateFields()
 
         opt_ids: List[int]
@@ -143,8 +140,9 @@ class RectangularMapping(SelectTool):
 
         mb = QMessageBox()
         mb.setText(
-            'Do you want to choose option 1 for corner point '
-            + str(len(corners) + 1) + '?'
+            "Do you want to choose option 1 for corner point "
+            + str(len(corners) + 1)
+            + "?"
         )
         mb.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         ret = mb.exec()
@@ -180,8 +178,9 @@ class RectangularMapping(SelectTool):
                 self._add_points(new_corner_points, corners, options_layer, opt_ids)
                 mb = QMessageBox()
                 mb.setText(
-                    'Do you want to choose option 1 for corner point '
-                    + str(len(corners) + 1) + '?'
+                    "Do you want to choose option 1 for corner point "
+                    + str(len(corners) + 1)
+                    + "?"
                 )
                 mb.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
                 ret = mb.exec()
@@ -193,7 +192,7 @@ class RectangularMapping(SelectTool):
                             to_be_deleted.append(opt_ids[3])
                             corners.append([new_corner_points[2], new_corner_points[3]])
                         else:
-                            to_be_deleted.append(opt_ids[2+(i*2-1)])
+                            to_be_deleted.append(opt_ids[2 + (i * 2 - 1)])
                             corners.append([new_corner_points[2], new_corner_points[3]])
                 # i.e. when ret == QMessageBox.Yes:
                 else:
@@ -202,7 +201,7 @@ class RectangularMapping(SelectTool):
                             to_be_deleted.append(opt_ids[4])
                             corners.append([new_corner_points[0], new_corner_points[1]])
                         else:
-                            to_be_deleted.append(opt_ids[2+(i*2)])
+                            to_be_deleted.append(opt_ids[2 + (i * 2)])
                             corners.append([new_corner_points[0], new_corner_points[1]])
 
         options_layer.deleteFeatures(to_be_deleted)
@@ -213,9 +212,7 @@ class RectangularMapping(SelectTool):
         op.actionOnExistingFile = QgsVectorFileWriter.AppendToLayerAddFields
         QgsVectorFileWriter.writeAsVectorFormat(options_layer, path, op)
 
-    def _calculate_parameters(
-        self, line_coords: List[Decimal]
-    ) -> List[Decimal]:
+    def _calculate_parameters(self, line_coords: List[Decimal]) -> List[Decimal]:
         """Calculate values for a, b and c parameters"""
         # a_measure is given in crs units (meters for EPSG: 3067)
         a_measure = Decimal(self.ui.get_a_measure())
@@ -228,47 +225,29 @@ class RectangularMapping(SelectTool):
             + (line_coords[1]) ** Decimal("2.0")
         )
         b = (
-            -Decimal("2.0")
-            * (line_coords[2]) ** Decimal("2.0")
-            * line_coords[0]
-            + Decimal("4.0")
-            * (line_coords[0]) ** Decimal("2.0")
-            * line_coords[2]
-            - Decimal("2.0")
-            * (line_coords[0]) ** Decimal("3.0")
-            - Decimal("2.0")
-            * (line_coords[3]) ** Decimal("2.0")
-            * line_coords[0]
-            + Decimal("4.0")
-            * line_coords[0] * line_coords[1]
-            * line_coords[3]
-            - Decimal("2.0")
-            * (line_coords[1]) ** Decimal("2.0")
-            * line_coords[0]
+            -Decimal("2.0") * (line_coords[2]) ** Decimal("2.0") * line_coords[0]
+            + Decimal("4.0") * (line_coords[0]) ** Decimal("2.0") * line_coords[2]
+            - Decimal("2.0") * (line_coords[0]) ** Decimal("3.0")
+            - Decimal("2.0") * (line_coords[3]) ** Decimal("2.0") * line_coords[0]
+            + Decimal("4.0") * line_coords[0] * line_coords[1] * line_coords[3]
+            - Decimal("2.0") * (line_coords[1]) ** Decimal("2.0") * line_coords[0]
         )
         c = (
-            - a_measure ** Decimal("2.0")
-            * (line_coords[2]) ** Decimal("2.0")
+            -(a_measure ** Decimal("2.0")) * (line_coords[2]) ** Decimal("2.0")
             + Decimal("2.0")
             * a_measure ** Decimal("2.0")
             * line_coords[0]
             * line_coords[2]
-            - a_measure ** Decimal("2.0")
-            * (line_coords[0]) ** Decimal("2.0")
-            + (line_coords[0]) ** Decimal("2.0")
-            * (line_coords[2]) ** Decimal("2.0")
-            - Decimal("2.0")
-            * (line_coords[0]) ** Decimal("3.0")
-            * line_coords[2]
+            - a_measure ** Decimal("2.0") * (line_coords[0]) ** Decimal("2.0")
+            + (line_coords[0]) ** Decimal("2.0") * (line_coords[2]) ** Decimal("2.0")
+            - Decimal("2.0") * (line_coords[0]) ** Decimal("3.0") * line_coords[2]
             + (line_coords[0]) ** Decimal("4.0")
-            + (line_coords[3]) ** Decimal("2.0")
-            * (line_coords[0]) ** Decimal("2.0")
+            + (line_coords[3]) ** Decimal("2.0") * (line_coords[0]) ** Decimal("2.0")
             - Decimal("2.0")
             * line_coords[1]
             * line_coords[3]
             * (line_coords[0]) ** Decimal("2.0")
-            + (line_coords[1]) ** Decimal("2.0")
-            * (line_coords[0]) ** Decimal("2.0")
+            + (line_coords[1]) ** Decimal("2.0") * (line_coords[0]) ** Decimal("2.0")
         )
         result = [a, b, c]
         return result
@@ -293,33 +272,28 @@ class RectangularMapping(SelectTool):
             return []
 
         # Coordinates of the first possible solution for point_a
-        x_a1 = (
-            (-parameters[1] + Decimal(math.sqrt(sqrt_in)))
-            / (Decimal("2.0") * parameters[0])
+        x_a1 = (-parameters[1] + Decimal(math.sqrt(sqrt_in))) / (
+            Decimal("2.0") * parameters[0]
         )
 
         y_a1 = (
-            (
-                x_a1 * line_coords[3]
-                - line_coords[0] * line_coords[3]
-                - x_a1 * line_coords[1]
-                + line_coords[2] * line_coords[1]
-            ) / (line_coords[2] - line_coords[0])
-        )
+            x_a1 * line_coords[3]
+            - line_coords[0] * line_coords[3]
+            - x_a1 * line_coords[1]
+            + line_coords[2] * line_coords[1]
+        ) / (line_coords[2] - line_coords[0])
 
         # Coordinates of the second possible solution for point_a
-        x_a2 = (
-            (-parameters[1] - Decimal(math.sqrt(sqrt_in)))
-            / (Decimal("2.0") * parameters[0])
+        x_a2 = (-parameters[1] - Decimal(math.sqrt(sqrt_in))) / (
+            Decimal("2.0") * parameters[0]
         )
 
         y_a2 = (
-            (x_a2 * line_coords[3]
-             - line_coords[0] * line_coords[3]
-             - x_a2 * line_coords[1]
-             + line_coords[2] * line_coords[1])
-            / (line_coords[2] - line_coords[0])
-        )
+            x_a2 * line_coords[3]
+            - line_coords[0] * line_coords[3]
+            - x_a2 * line_coords[1]
+            + line_coords[2] * line_coords[1]
+        ) / (line_coords[2] - line_coords[0])
 
         bound_x = sorted([line_coords[0], line_coords[2]])
         bound_y = sorted([line_coords[1], line_coords[3]])
@@ -327,8 +301,10 @@ class RectangularMapping(SelectTool):
         # Select the correct solution point (the one existing
         # at the property boundary line selected by the user)
         if (
-            x_a1 > bound_x[0] and x_a1 < bound_x[1]
-            and y_a1 > bound_y[0] and y_a1 < bound_y[1]
+            x_a1 > bound_x[0]
+            and x_a1 < bound_x[1]
+            and y_a1 > bound_y[0]
+            and y_a1 < bound_y[1]
         ):
             x_a = x_a1
             y_a = y_a1
@@ -359,51 +335,63 @@ class RectangularMapping(SelectTool):
 
         # Coordinates of the first possible solution point
         x_b1 = (
-            (line_coords[3] * b_measure * Decimal(math.sqrt(
-                a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-            ))
-              - line_coords[1] * b_measure * Decimal(math.sqrt(
-                    a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-                )) - b2 * y_a * line_coords[3]
-              + b2 * y_a * line_coords[1]
-              - b2 * x_a * line_coords[2] + b2 * x_a * line_coords[0]
-              - c2 * line_coords[3] + c2 * line_coords[1]
-              )
-            / (a2 * line_coords[3] - a2 * line_coords[1]
-               - b2 * line_coords[2] + b2 * line_coords[0])
+            line_coords[3]
+            * b_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - line_coords[1]
+            * b_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - b2 * y_a * line_coords[3]
+            + b2 * y_a * line_coords[1]
+            - b2 * x_a * line_coords[2]
+            + b2 * x_a * line_coords[0]
+            - c2 * line_coords[3]
+            + c2 * line_coords[1]
+        ) / (
+            a2 * line_coords[3]
+            - a2 * line_coords[1]
+            - b2 * line_coords[2]
+            + b2 * line_coords[0]
         )
 
         y_b1 = (
-            (y_a * line_coords[3] - y_a * line_coords[1]
-             - Decimal(x_b1) * line_coords[2]
-             + Decimal(x_b1) * line_coords[0]
-             + x_a * line_coords[2] - x_a * line_coords[0])
-            / (line_coords[3] - line_coords[1])
-        )
+            y_a * line_coords[3]
+            - y_a * line_coords[1]
+            - Decimal(x_b1) * line_coords[2]
+            + Decimal(x_b1) * line_coords[0]
+            + x_a * line_coords[2]
+            - x_a * line_coords[0]
+        ) / (line_coords[3] - line_coords[1])
 
         # Coordinates of the second possible solution point
         x_b2 = (
-            (-line_coords[3] * b_measure * Decimal(math.sqrt(
-                a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-            ))
-             + line_coords[1] * b_measure * Decimal(math.sqrt(
-                    a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-                )) - b2 * y_a * line_coords[3]
-             + b2 * y_a * line_coords[1]
-             - b2 * x_a * line_coords[2] + b2 * x_a * line_coords[0]
-             - c2 * line_coords[3] + c2 * line_coords[1]
-             )
-            / (a2 * line_coords[3] - a2 * line_coords[1]
-               - b2 * line_coords[2] + b2 * line_coords[0])
+            -line_coords[3]
+            * b_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            + line_coords[1]
+            * b_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - b2 * y_a * line_coords[3]
+            + b2 * y_a * line_coords[1]
+            - b2 * x_a * line_coords[2]
+            + b2 * x_a * line_coords[0]
+            - c2 * line_coords[3]
+            + c2 * line_coords[1]
+        ) / (
+            a2 * line_coords[3]
+            - a2 * line_coords[1]
+            - b2 * line_coords[2]
+            + b2 * line_coords[0]
         )
 
         y_b2 = (
-            (y_a * line_coords[3] - y_a * line_coords[1]
-             - Decimal(x_b2) * line_coords[2]
-             + Decimal(x_b2) * line_coords[0]
-             + x_a * line_coords[2] - x_a * line_coords[0])
-            / (line_coords[3] - line_coords[1])
-        )
+            y_a * line_coords[3]
+            - y_a * line_coords[1]
+            - Decimal(x_b2) * line_coords[2]
+            + Decimal(x_b2) * line_coords[0]
+            + x_a * line_coords[2]
+            - x_a * line_coords[0]
+        ) / (line_coords[3] - line_coords[1])
 
         # Check that the solution points lie in the
         # map canvas extent
@@ -442,37 +430,32 @@ class RectangularMapping(SelectTool):
     ) -> List[Decimal]:
         """Determine the coordinates of corner point 2."""
 
-        a = (
-            Decimal("1.0")
-            + (
-                (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
-            ) ** Decimal("2.0")
-        )
+        a = Decimal("1.0") + (
+            (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
+        ) ** Decimal("2.0")
         b = (
-            - Decimal("2.0") * point_b[0]
-            - Decimal("2.0") * point_a[0] * (
-                (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
-            ) ** Decimal("2.0")
-            + Decimal("2.0") * (
-                (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
-            ) * (point_a[1] - point_b[1])
+            -Decimal("2.0") * point_b[0]
+            - Decimal("2.0")
+            * point_a[0]
+            * ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0])) ** Decimal("2.0")
+            + Decimal("2.0")
+            * ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0]))
+            * (point_a[1] - point_b[1])
         )
         c = (
-            - c_measure ** Decimal("2.0") + (point_a[1] - point_b[1]) ** Decimal("2.0")
-            - Decimal("2.0") * (
-                (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
-            ) * (point_a[1] - point_b[1]) * point_a[0]
+            -(c_measure ** Decimal("2.0"))
+            + (point_a[1] - point_b[1]) ** Decimal("2.0")
+            - Decimal("2.0")
+            * ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0]))
+            * (point_a[1] - point_b[1])
+            * point_a[0]
             + point_b[0] ** Decimal("2.0")
-            + point_a[0] ** Decimal("2.0") * (
-                (point_b[1] - point_a[1]) / (point_b[0] - point_a[0])
-            ) ** Decimal("2.0")
+            + point_a[0] ** Decimal("2.0")
+            * ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0])) ** Decimal("2.0")
         )
 
         # Check that the solution exists
-        sqrt_in = (
-            b ** Decimal("2.0")
-            - Decimal("4.0") * a * c
-        )
+        sqrt_in = b ** Decimal("2.0") - Decimal("4.0") * a * c
         if sqrt_in < 0.0 or a == 0.0:
             LOGGER.warning(
                 tr("Solution point does not exist!"),
@@ -481,35 +464,29 @@ class RectangularMapping(SelectTool):
             return []
 
         # Computing the possible coordinates for corner point 2
-        x_c1 = (
-            (-b + Decimal(math.sqrt(sqrt_in))) / (Decimal("2.0") * a)
-        )
+        x_c1 = (-b + Decimal(math.sqrt(sqrt_in))) / (Decimal("2.0") * a)
 
-        y_c1 = (
-            ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0]))
-            * (x_c1 - point_a[0]) + point_a[1]
-        )
+        y_c1 = ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0])) * (
+            x_c1 - point_a[0]
+        ) + point_a[1]
 
         # Computing the possible coordinates for corner point 2
-        x_c2 = (
-            (-b - Decimal(math.sqrt(sqrt_in))) / (Decimal("2.0") * a)
-        )
+        x_c2 = (-b - Decimal(math.sqrt(sqrt_in))) / (Decimal("2.0") * a)
 
-        y_c2 = (
-            ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0]))
-            * (x_c2 - point_a[0]) + point_a[1]
-        )
+        y_c2 = ((point_b[1] - point_a[1]) / (point_b[0] - point_a[0])) * (
+            x_c2 - point_a[0]
+        ) + point_a[1]
 
         # Let's find out which solution point has more distance to
         # point_b. Assumption: the corner point located via a and b
         # measures will be the closest to the boundary line
-        d1 = (
-            math.sqrt((x_c1-point_a[0]) ** Decimal("2.0")
-                      + (y_c1-point_a[1]) ** Decimal("2.0"))
+        d1 = math.sqrt(
+            (x_c1 - point_a[0]) ** Decimal("2.0")
+            + (y_c1 - point_a[1]) ** Decimal("2.0")
         )
-        d2 = (
-            math.sqrt((x_c2 - point_a[0]) ** Decimal("2.0")
-                      + (y_c2 - point_a[1]) ** Decimal("2.0"))
+        d2 = math.sqrt(
+            (x_c2 - point_a[0]) ** Decimal("2.0")
+            + (y_c2 - point_a[1]) ** Decimal("2.0")
         )
 
         if d1 < d2:
@@ -535,51 +512,53 @@ class RectangularMapping(SelectTool):
 
         # Coordinates of the first possible solution point
         x_d1 = (
-            (point2[1] * d_measure * Decimal(math.sqrt(
-                a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-            ))
-              - point1[1] * d_measure * Decimal(math.sqrt(
-                    a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-                )) - b2 * point2[1] * point2[1]
-              + b2 * point2[1] * point1[1]
-              - b2 * point2[0] ** Decimal("2.0") + b2 * point2[0] * point1[0]
-              - c2 * point2[1] + c2 * point1[1]
-              )
-            / (a2 * point2[1] - a2 * point1[1]
-               - b2 * point2[0] + b2 * point1[0])
-        )
+            point2[1]
+            * d_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - point1[1]
+            * d_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - b2 * point2[1] * point2[1]
+            + b2 * point2[1] * point1[1]
+            - b2 * point2[0] ** Decimal("2.0")
+            + b2 * point2[0] * point1[0]
+            - c2 * point2[1]
+            + c2 * point1[1]
+        ) / (a2 * point2[1] - a2 * point1[1] - b2 * point2[0] + b2 * point1[0])
 
         y_d1 = (
-            (point2[1] ** Decimal("2.0") - point2[1] * point1[1]
-             - Decimal(x_d1) * point2[0]
-             + Decimal(x_d1) * point1[0]
-             + point2[0] ** Decimal("2.0") - point2[0] * point1[0])
-            / (point2[1] - point1[1])
-        )
+            point2[1] ** Decimal("2.0")
+            - point2[1] * point1[1]
+            - Decimal(x_d1) * point2[0]
+            + Decimal(x_d1) * point1[0]
+            + point2[0] ** Decimal("2.0")
+            - point2[0] * point1[0]
+        ) / (point2[1] - point1[1])
 
         # Coordinates of the second possible solution point
         x_d2 = (
-            (-point2[1] * d_measure * Decimal(math.sqrt(
-                a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-            ))
-             + point1[1] * d_measure * Decimal(math.sqrt(
-                    a2 ** Decimal("2.0") + b2 ** Decimal("2.0")
-                )) - b2 * point2[1] ** Decimal("2.0")
-             + b2 * point2[1] * point1[1]
-             - b2 * point2[0] ** Decimal("2.0") + b2 * point2[0] * point1[0]
-             - c2 * point2[1] + c2 * point1[1]
-             )
-            / (a2 * point2[1] - a2 * point1[1]
-               - b2 * point2[0] + b2 * point1[0])
-        )
+            -point2[1]
+            * d_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            + point1[1]
+            * d_measure
+            * Decimal(math.sqrt(a2 ** Decimal("2.0") + b2 ** Decimal("2.0")))
+            - b2 * point2[1] ** Decimal("2.0")
+            + b2 * point2[1] * point1[1]
+            - b2 * point2[0] ** Decimal("2.0")
+            + b2 * point2[0] * point1[0]
+            - c2 * point2[1]
+            + c2 * point1[1]
+        ) / (a2 * point2[1] - a2 * point1[1] - b2 * point2[0] + b2 * point1[0])
 
         y_d2 = (
-            (point2[1] ** Decimal("2.0") - point2[1] * point1[1]
-             - Decimal(x_d2) * point2[0]
-             + Decimal(x_d2) * point1[0]
-             + point2[0] ** Decimal("2.0") - point2[0] * point1[0])
-            / (point2[1] - point1[1])
-        )
+            point2[1] ** Decimal("2.0")
+            - point2[1] * point1[1]
+            - Decimal(x_d2) * point2[0]
+            + Decimal(x_d2) * point1[0]
+            + point2[0] ** Decimal("2.0")
+            - point2[0] * point1[0]
+        ) / (point2[1] - point1[1])
 
         # Check that the corner points lie in the
         # map canvas extent
@@ -615,8 +594,10 @@ class RectangularMapping(SelectTool):
 
     def _add_points(
         self,
-        points: List[Decimal], corners: List[List[Decimal]],
-        options_layer: QgsVectorLayer, opt_ids: List[int]
+        points: List[Decimal],
+        corners: List[List[Decimal]],
+        options_layer: QgsVectorLayer,
+        opt_ids: List[int],
     ) -> None:
         """Triggered when scratch layers need to be generated."""
 
@@ -624,11 +605,11 @@ class RectangularMapping(SelectTool):
         f1 = QgsFeature()
         f1.setGeometry(QgsGeometry.fromPointXY(point))
         if len(corners) == 0:
-            f1.setAttributes(['Point B opt 1'])
+            f1.setAttributes(["Point B opt 1"])
         elif len(corners) == 1:
-            f1.setAttributes(['Corner 2'])
+            f1.setAttributes(["Corner 2"])
         else:
-            f1.setAttributes(['Corner ' + str(len(corners)+1) + ' opt 1'])
+            f1.setAttributes(["Corner " + str(len(corners) + 1) + " opt 1"])
 
         options_layer_dataprovider = options_layer.dataProvider()
         options_layer_dataprovider.addFeature(f1)
@@ -671,9 +652,9 @@ class RectangularMapping(SelectTool):
             f2 = QgsFeature()
             f2.setGeometry(QgsGeometry.fromPointXY(point2))
             if len(corners) == 0:
-                f2.setAttributes(['Point B opt 2'])
+                f2.setAttributes(["Point B opt 2"])
             else:
-                f2.setAttributes(['Corner ' + str(len(corners)+1) + ' opt 2'])
+                f2.setAttributes(["Corner " + str(len(corners) + 1) + " opt 2"])
             options_layer_dataprovider.addFeature(f2)
             options_layer.updateExtents()
             opt_ids.append(f2.id())

--- a/kimu/core/rectangular_tool.py
+++ b/kimu/core/rectangular_tool.py
@@ -86,6 +86,8 @@ class RectangularMapping(SelectTool):
         c_measures = [
             Decimal(measure.strip()) for measure in self.ui.get_c_measures().split(",")
         ]
+        if len(c_measures) == 2:
+            c_measures *= 2
 
         for i, c_measure in enumerate(c_measures):  # TODO: refactor loop
             if i == 0:

--- a/kimu/plugin.py
+++ b/kimu/plugin.py
@@ -169,7 +169,7 @@ class Plugin:
         self.intersection_tool_line_circle.setAction(line_circle_action)
         rectangular_action = self.add_action(
             "",
-            text=tr("Find rectangular point"),
+            text=tr("Rectangular mapping"),
             callback=self.activate_rectangular_tool,
             parent=self.iface.mainWindow(),
             add_to_menu=False,

--- a/kimu/plugin.py
+++ b/kimu/plugin.py
@@ -42,7 +42,7 @@ class Plugin:
         self.intersection_tool_line_circle = IntersectionLineCircle(
             self.iface, line_circle_dockwidget
         )
-        self.rectangular_tool = RectangularMapping(self.iface, rectangular_dockwidget)
+        self.rectangular_tool = RectangularMapping(rectangular_dockwidget)
 
         # Initialize locale
         locale, file_path = setup_translation()

--- a/kimu/resources/ui/rectangular_dockwidget.ui
+++ b/kimu/resources/ui/rectangular_dockwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Rectangular mapping of a point</string>
+   <string>Rectangular mapping of points with respect to the line</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QHBoxLayout" name="horizontalLayout">
@@ -51,7 +51,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of C-measures&lt;/p&gt;&lt;p&gt;(in crs units, separated by comma)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of the building wall widths&lt;/p&gt;&lt;p&gt;to be mapped rectangularly&lt;/p&gt;&lt;p&gt;(in crs units, separated by comma)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
@@ -61,7 +61,7 @@
       <item row="6" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Select output file</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select output file (crs of the&lt;/p&gt;&lt;p&gt;file should match with crs &lt;/p&gt;&lt;p&gt;of the utilized line layer)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/kimu/resources/ui/rectangular_dockwidget.ui
+++ b/kimu/resources/ui/rectangular_dockwidget.ui
@@ -29,8 +29,17 @@
       </item>
       <item row="2" column="1">
        <widget class="QDoubleSpinBox" name="doublespinbox_a">
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="minimum">
+         <double>-99999999.000000000000000</double>
+        </property>
         <property name="maximum">
-         <double>1000000000.000000000000000</double>
+         <double>99999999.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
         </property>
        </widget>
       </item>
@@ -43,8 +52,14 @@
       </item>
       <item row="3" column="1">
        <widget class="QDoubleSpinBox" name="doublespinbox_b">
+        <property name="decimals">
+         <number>3</number>
+        </property>
         <property name="maximum">
-         <double>1000000000.000000000000000</double>
+         <double>99999999.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.001000000000000</double>
         </property>
        </widget>
       </item>

--- a/kimu/resources/ui/rectangular_dockwidget.ui
+++ b/kimu/resources/ui/rectangular_dockwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>552</width>
-    <height>111</height>
+    <width>767</width>
+    <height>365</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,13 +34,6 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="doublespinbox_b">
-        <property name="maximum">
-         <double>1000000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -48,11 +41,45 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="QDoubleSpinBox" name="doublespinbox_b">
+        <property name="maximum">
+         <double>1000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of C-measures&lt;/p&gt;&lt;p&gt;(in crs units, separated by comma)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QTextEdit" name="textEdit"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Select output file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QgsFileWidget" name="mQgsFileWidget"/>
+      </item>
      </layout>
     </item>
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/kimu/ui/rectangular_dockwidget.py
+++ b/kimu/ui/rectangular_dockwidget.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QWidget
-from qgis.gui import QgisInterface, QgsDoubleSpinBox
+from PyQt5.QtWidgets import QTextEdit, QWidget
+from qgis.gui import QgisInterface, QgsDoubleSpinBox, QgsFileWidget
 from qgis.PyQt import QtWidgets
 
 from ..qgis_plugin_tools.tools.resources import load_ui
@@ -20,3 +20,11 @@ class RectangularDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     def get_b_measure(self) -> float:
         self.doublespinbox_b: QgsDoubleSpinBox
         return self.doublespinbox_b.value()
+
+    def get_c_measures(self) -> str:
+        self.textEdit: QTextEdit
+        return self.textEdit.toPlainText()
+
+    def get_output_file(self) -> str:
+        self.mQgsFileWidget: QgsFileWidget
+        return self.mQgsFileWidget.filePath()

--- a/kimu/ui/rectangular_dockwidget.py
+++ b/kimu/ui/rectangular_dockwidget.py
@@ -25,6 +25,6 @@ class RectangularDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.textEdit: QTextEdit
         return self.textEdit.toPlainText()
 
-    def get_output_file(self) -> str:
+    def get_output_file_path(self) -> str:
         self.mQgsFileWidget: QgsFileWidget
         return self.mQgsFileWidget.filePath()


### PR DESCRIPTION
Allow users to continue creating corner points of a building after they have located the first corner point of the building via A and B measures. List of applicable c_measures can be left empty, too.